### PR TITLE
Refactor: webview_flutter to 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ dependencies {
 }
 ```
 
-### ThePeer Send
+### Thepeer Send
 
 - Launch ThepeerSendView in a bottom_sheet
 
@@ -34,7 +34,7 @@ import 'package:thepeer_flutter/thepeer_flutter.dart';
 
   void launch() async {
       await ThepeerSendView(
-               data: ThePeerData(
+               data: ThepeerData(
                   amount: 400000,
                   publicKey: "pspk_one_more_thing",
                   userReference: "stay-foolish-stay-hungry-forever",
@@ -66,7 +66,7 @@ import 'package:thepeer_flutter/thepeer_flutter.dart';
      ...
 
      ThepeerSendView(
-         data: ThePeerData(
+         data: ThepeerData(
             amount: 10000,
             publicKey: "pspk_one_more_thing",
             userReference: "stay-foolish-stay-hungry-forever",
@@ -94,7 +94,7 @@ import 'package:thepeer_flutter/thepeer_flutter.dart';
 
 ---
 
-### ThePeer DirectCharge
+### Thepeer DirectCharge
 
 - Launch ThepeerDirectChargeView in a bottom_sheet
 
@@ -103,7 +103,7 @@ import 'package:thepeer_flutter/thepeer_flutter.dart';
 
   void launch() async {
     await ThepeerDirectChargeView(
-            data: ThePeerData(
+            data: ThepeerData(
               amount: 10000,
               publicKey: "pspk_one_more_thing",
               userReference: "stay-foolish-stay-hungry-forever",
@@ -135,7 +135,7 @@ import 'package:thepeer_flutter/thepeer_flutter.dart';
      ...
 
       await ThepeerDirectChargeView(
-            data: ThePeerData(
+            data: ThepeerData(
               amount: 10000,
               publicKey: "pspk_one_more_thing",
               userReference: "stay-foolish-stay-hungry-forever",
@@ -163,7 +163,7 @@ import 'package:thepeer_flutter/thepeer_flutter.dart';
 
 ---
 
-### ThePeer Checkout
+### Thepeer Checkout
 
 - Launch ThepeerCheckoutView in a bottom_sheet
 
@@ -172,7 +172,7 @@ import 'package:thepeer_flutter/thepeer_flutter.dart';
 
   void launch() async {
     await ThepeerCheckoutView(
-            data: ThePeerData(
+            data: ThepeerData(
               amount: 10000,
               publicKey: "pspk_one_more_thing",
               userReference: "stay-foolish-stay-hungry-forever",
@@ -204,7 +204,7 @@ import 'package:thepeer_flutter/thepeer_flutter.dart';
      ...
 
       await ThepeerCheckoutView(
-            data: ThePeerData(
+            data: ThepeerData(
               amount: 10000,
               publicKey: "pspk_one_more_thing",
               userReference: "stay-foolish-stay-hungry-forever",

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -78,7 +78,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     onPressed: () async {
                       await ThepeerCheckoutView(
                         email: 'test@gmail.com',
-                        data: ThePeerData(
+                        data: ThepeerData(
                           publicKey:
                               "pspk_test_2aj8xasztf4domzd2nphinvzkvecpbuyxldkvr3pkuvko",
                           amount: 400000,
@@ -123,7 +123,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     ),
                     onPressed: () async {
                       await ThepeerSendView(
-                        data: ThePeerData(
+                        data: ThepeerData(
                           publicKey:
                               "pspk_test_2aj8xasztf4domzd2nphinvzkvecpbuyxldkvr3pkuvko",
                           amount: 400000,
@@ -168,7 +168,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     ),
                     onPressed: () async {
                       await ThepeerDirectChargeView(
-                        data: ThePeerData(
+                        data: ThepeerData(
                           publicKey:
                               "pspk_test_2aj8xasztf4domzd2nphinvzkvecpbuyxldkvr3pkuvko",
                           amount: 400000,

--- a/lib/src/const/const.dart
+++ b/lib/src/const/const.dart
@@ -1,4 +1,5 @@
 const package = 'thepeer_flutter';
+const baseUrl = 'https://chain.thepeer.co?';
 
 const SEND_SUCCESS = 'send.success';
 const SEND_ERROR = 'send.server_error';

--- a/lib/src/model/thepeer_data.dart
+++ b/lib/src/model/thepeer_data.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:equatable/equatable.dart';
 
-class ThePeerData with EquatableMixin {
+class ThepeerData with EquatableMixin {
   /// Your public key an be found on your dashboard settings
   final String publicKey;
 
@@ -20,7 +20,7 @@ class ThePeerData with EquatableMixin {
 
   bool get isProd => publicKey.contains('test') == false;
 
-  ThePeerData({
+  ThepeerData({
     required this.publicKey,
     required this.userReference,
     required this.currency,
@@ -28,7 +28,7 @@ class ThePeerData with EquatableMixin {
     this.meta = const {},
   });
 
-  ThePeerData copyWith({
+  ThepeerData copyWith({
     String? publicKey,
     String? userReference,
     String? currency,
@@ -36,7 +36,7 @@ class ThePeerData with EquatableMixin {
     Map<String, Object>? meta,
     int? amount,
   }) {
-    return ThePeerData(
+    return ThepeerData(
       publicKey: publicKey ?? this.publicKey,
       userReference: userReference ?? this.userReference,
       amount: amount ?? this.amount,
@@ -54,8 +54,8 @@ class ThePeerData with EquatableMixin {
     };
   }
 
-  factory ThePeerData.fromMap(Map<String, dynamic> map) {
-    return ThePeerData(
+  factory ThepeerData.fromMap(Map<String, dynamic> map) {
+    return ThepeerData(
       publicKey: map['publicKey'],
       userReference: map['userReference'],
       amount: map['amount'],
@@ -66,8 +66,8 @@ class ThePeerData with EquatableMixin {
 
   String toJson() => json.encode(toMap());
 
-  factory ThePeerData.fromJson(String source) =>
-      ThePeerData.fromMap(json.decode(source));
+  factory ThepeerData.fromJson(String source) =>
+      ThepeerData.fromMap(json.decode(source));
 
   @override
   bool? get stringify => true;

--- a/lib/src/utils/functions.dart
+++ b/lib/src/utils/functions.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:thepeer_flutter/src/model/thepeer_data.dart';
 import 'package:thepeer_flutter/src/utils/extensions.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class ThePeerFunctions {
   /// `[JS]` Create EventListener config for message client
@@ -83,5 +84,16 @@ class ThePeerFunctions {
         'meta': jsonEncode(data.meta),
       },
     );
+  }
+
+  /// Open url in an external browser
+  static void launchExternalUrl(
+      {required String url, required bool showLogs}) async {
+    try {
+      await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+    } catch (e) {
+      // handle failure
+      if (showLogs == true) ThePeerFunctions.log(e.toString());
+    }
   }
 }

--- a/lib/src/utils/functions.dart
+++ b/lib/src/utils/functions.dart
@@ -5,7 +5,7 @@ import 'package:thepeer_flutter/src/model/thepeer_data.dart';
 import 'package:thepeer_flutter/src/utils/extensions.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class ThePeerFunctions {
+class ThepeerFunctions {
   /// `[JS]` Create EventListener config for message client
   static String peerMessageHandler(String clientName) => '''
 
@@ -47,11 +47,11 @@ class ThePeerFunctions {
 ''';
 
   /// Log data from thepeer sdk
-  static void log(String data) => debugPrint('ThePeerLog: $data');
+  static void log(String data) => debugPrint('ThepeerLog: $data');
 
   /// Create peer url
   static Uri createUrl({
-    required ThePeerData data,
+    required ThepeerData data,
     String? email,
     required String sdkType,
   }) {
@@ -93,7 +93,7 @@ class ThePeerFunctions {
       await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
     } catch (e) {
       // handle failure
-      if (showLogs == true) ThePeerFunctions.log(e.toString());
+      if (showLogs == true) ThepeerFunctions.log(e.toString());
     }
   }
 }

--- a/lib/src/utils/functions.dart
+++ b/lib/src/utils/functions.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
+import 'package:thepeer_flutter/src/const/const.dart';
 import 'package:thepeer_flutter/src/model/thepeer_data.dart';
 import 'package:thepeer_flutter/src/utils/extensions.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -49,13 +50,17 @@ class ThepeerFunctions {
   /// Log data from thepeer sdk
   static void log(String data) => debugPrint('ThepeerLog: $data');
 
+  /// converts the base url to only domain name e.g [https://chain.thepeer.co?] returns [chain.thepeer.co]
+  static String domainName =
+      baseUrl.replaceAll("https://", "").substring(0, baseUrl.length - 1);
+
   /// Create peer url
   static Uri createUrl({
     required ThepeerData data,
     String? email,
     required String sdkType,
   }) {
-    var base = 'https://chain.thepeer.co?';
+    var base = baseUrl;
 
     final params = {
       'publicKey': data.publicKey,

--- a/lib/src/utils/the_peer_error_view.dart
+++ b/lib/src/utils/the_peer_error_view.dart
@@ -6,12 +6,12 @@ import 'package:thepeer_flutter/src/utils/colors.dart';
 import 'package:thepeer_flutter/src/widgets/the_peer_button.dart';
 import 'package:thepeer_flutter/src/widgets/touchable_opacity.dart';
 
-/// ThePeerErrorView States Widget
-class ThePeerErrorView extends StatelessWidget {
+/// ThepeerErrorView States Widget
+class ThepeerErrorView extends StatelessWidget {
   final VoidCallback reload;
   final VoidCallback? onClosed;
 
-  const ThePeerErrorView({
+  const ThepeerErrorView({
     Key? key,
     this.onClosed,
     required this.reload,

--- a/lib/src/views/the_peer_checkout_view.dart
+++ b/lib/src/views/the_peer_checkout_view.dart
@@ -72,7 +72,7 @@ class ThepeerCheckoutView extends StatefulWidget {
             topRight: Radius.circular(10),
           ),
           child: SizedBox(
-            height: MediaQuery.of(context).size.height * 0.9,
+            height: MediaQuery.of(context).size.height,
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [

--- a/lib/src/views/the_peer_checkout_view.dart
+++ b/lib/src/views/the_peer_checkout_view.dart
@@ -259,7 +259,8 @@ class _ThepeerCheckoutViewState extends State<ThepeerCheckoutView> {
       // Navigate to all urls contianing Thepeer
       return NavigationDecision.navigate;
     } else {
-      // Block all navigations outside Thepeer
+      //Prevent external navigations from opening in the webview and open in an external browser instead.
+      ThePeerFunctions.launchExternalUrl(url: url, showLogs: (widget.showLogs));
       return NavigationDecision.prevent;
     }
   }

--- a/lib/src/views/the_peer_checkout_view.dart
+++ b/lib/src/views/the_peer_checkout_view.dart
@@ -253,8 +253,8 @@ class _ThepeerCheckoutViewState extends State<ThepeerCheckoutView> {
   NavigationDecision _handleNavigationInterceptor(NavigationRequest request) {
     final url = request.url.toLowerCase();
 
-    if (url.contains('groot.thepeer.co') || url.contains('chain.thepeer.co')) {
-      // Navigate to all urls contianing Thepeer
+    if (url.contains(ThepeerFunctions.domainName)) {
+      // Navigate to all urls contianing Thepeer domain
       return NavigationDecision.navigate;
     } else {
       //Prevent external navigations from opening in the webview and open in an external browser instead.

--- a/lib/src/views/the_peer_checkout_view.dart
+++ b/lib/src/views/the_peer_checkout_view.dart
@@ -19,7 +19,7 @@ import 'package:thepeer_flutter/src/views/the_peer_error_view.dart';
 
 class ThepeerCheckoutView extends StatefulWidget {
   /// Public Key from your https://app.withThepeer.com/apps
-  final ThePeerData data;
+  final ThepeerData data;
 
   /// User email
   final String email;
@@ -125,7 +125,7 @@ class _ThepeerCheckoutViewState extends State<ThepeerCheckoutView> {
     _handleInit();
   }
 
-  String get createUrl => ThePeerFunctions.createUrl(
+  String get createUrl => ThepeerFunctions.createUrl(
         data: widget.data,
         email: widget.email,
         sdkType: 'checkout',
@@ -142,7 +142,7 @@ class _ThepeerCheckoutViewState extends State<ThepeerCheckoutView> {
           if (hasError == true) {
             return Center(
               child: widget.errorWidget ??
-                  ThePeerErrorView(
+                  ThepeerErrorView(
                     onClosed: widget.onClosed,
                     reload: () async {
                       await _controller.reload();
@@ -177,7 +177,7 @@ class _ThepeerCheckoutViewState extends State<ThepeerCheckoutView> {
   /// Inject JS code to be run in webview
   Future<void> _injectPeerStack(WebViewController controller) async {
     await controller.runJavaScript(
-      ThePeerFunctions.peerMessageHandler(
+      ThepeerFunctions.peerMessageHandler(
         'ThepeerSendClientInterface',
       ),
     );
@@ -201,7 +201,7 @@ class _ThepeerCheckoutViewState extends State<ThepeerCheckoutView> {
           return;
       }
     } catch (e) {
-      if (widget.showLogs == true) ThePeerFunctions.log(e.toString());
+      if (widget.showLogs == true) ThepeerFunctions.log(e.toString());
     }
   }
 
@@ -224,7 +224,7 @@ class _ThepeerCheckoutViewState extends State<ThepeerCheckoutView> {
           },
           onWebResourceError: (e) {
             hasError = true;
-            if (widget.showLogs) ThePeerFunctions.log(e.toString());
+            if (widget.showLogs) ThepeerFunctions.log(e.toString());
           },
           onPageFinished: (_) async {
             isLoading = false;
@@ -241,12 +241,12 @@ class _ThepeerCheckoutViewState extends State<ThepeerCheckoutView> {
   /// Javascript channel  onMessageRecieved for events sent by Thepeer
   void _onMessageReceived(JavaScriptMessage data) {
     try {
-      if (widget.showLogs) ThePeerFunctions.log('Event: -> ${data.message}');
+      if (widget.showLogs) ThepeerFunctions.log('Event: -> ${data.message}');
       _handleResponse(data.message);
     } on Exception {
       if (mounted && widget.onClosed != null) widget.onClosed!();
     } catch (e) {
-      if (widget.showLogs) ThePeerFunctions.log(e.toString());
+      if (widget.showLogs) ThepeerFunctions.log(e.toString());
     }
   }
 
@@ -258,7 +258,7 @@ class _ThepeerCheckoutViewState extends State<ThepeerCheckoutView> {
       return NavigationDecision.navigate;
     } else {
       //Prevent external navigations from opening in the webview and open in an external browser instead.
-      ThePeerFunctions.launchExternalUrl(url: url, showLogs: (widget.showLogs));
+      ThepeerFunctions.launchExternalUrl(url: url, showLogs: (widget.showLogs));
       return NavigationDecision.prevent;
     }
   }

--- a/lib/src/views/the_peer_direct_charge_view.dart
+++ b/lib/src/views/the_peer_direct_charge_view.dart
@@ -69,7 +69,7 @@ class ThepeerDirectChargeView extends StatefulWidget {
             topRight: Radius.circular(10),
           ),
           child: SizedBox(
-            height: MediaQuery.of(context).size.height * 0.9,
+            height: MediaQuery.of(context).size.height,
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
@@ -219,7 +219,6 @@ class _ThepeerDirectChargeViewState extends State<ThepeerDirectChargeView> {
   void _handleInit() async {
     await SystemChannels.textInput.invokeMethod<String>('TextInput.hide');
 
-    //                 navigationDelegate: _handleNavigationInterceptor,
     final WebViewController controller =
         WebViewController.fromPlatformCreationParams(
             PlatformWebViewControllerCreationParams());

--- a/lib/src/views/the_peer_direct_charge_view.dart
+++ b/lib/src/views/the_peer_direct_charge_view.dart
@@ -260,7 +260,7 @@ class _ThepeerDirectChargeViewState extends State<ThepeerDirectChargeView> {
   NavigationDecision _handleNavigationInterceptor(NavigationRequest request) {
     final url = request.url.toLowerCase();
 
-    if (url.contains('groot.thepeer.co') || url.contains('chain.thepeer.co')) {
+    if (url.contains(ThepeerFunctions.domainName)) {
       // Navigate to all urls contianing Thepeer
       return NavigationDecision.navigate;
     } else {

--- a/lib/src/views/the_peer_direct_charge_view.dart
+++ b/lib/src/views/the_peer_direct_charge_view.dart
@@ -19,7 +19,7 @@ import 'package:thepeer_flutter/src/views/the_peer_error_view.dart';
 
 class ThepeerDirectChargeView extends StatefulWidget {
   /// Public Key from your https://app.withThepeer.com/apps
-  final ThePeerData data;
+  final ThepeerData data;
 
   /// Success callback
   final ValueChanged<dynamic>? onSuccess;
@@ -120,7 +120,7 @@ class _ThepeerDirectChargeViewState extends State<ThepeerDirectChargeView> {
     setState(() {});
   }
 
-  String get createUrl => ThePeerFunctions.createUrl(
+  String get createUrl => ThepeerFunctions.createUrl(
         data: widget.data,
         sdkType: 'directCharge',
       ).toString();
@@ -142,7 +142,7 @@ class _ThepeerDirectChargeViewState extends State<ThepeerDirectChargeView> {
           if (hasError == true) {
             return Center(
               child: widget.errorWidget ??
-                  ThePeerErrorView(
+                  ThepeerErrorView(
                     onClosed: widget.onClosed,
                     reload: () async {
                       setState(() {});
@@ -182,7 +182,7 @@ class _ThepeerDirectChargeViewState extends State<ThepeerDirectChargeView> {
   /// Inject JS code to be run in webview
   Future<void> _injectPeerStack(WebViewController controller) {
     return controller.runJavaScript(
-      ThePeerFunctions.peerMessageHandler(
+      ThepeerFunctions.peerMessageHandler(
         'ThepeerDirectChargeClientInterface',
       ),
     );
@@ -208,7 +208,7 @@ class _ThepeerDirectChargeViewState extends State<ThepeerDirectChargeView> {
           return;
       }
     } catch (e) {
-      if (widget.showLogs) ThePeerFunctions.log(e.toString());
+      if (widget.showLogs) ThepeerFunctions.log(e.toString());
     }
   }
 
@@ -231,7 +231,7 @@ class _ThepeerDirectChargeViewState extends State<ThepeerDirectChargeView> {
           },
           onWebResourceError: (e) {
             hasError = true;
-            if (widget.showLogs) ThePeerFunctions.log(e.toString());
+            if (widget.showLogs) ThepeerFunctions.log(e.toString());
           },
           onPageFinished: (_) async {
             isLoading = false;
@@ -248,12 +248,12 @@ class _ThepeerDirectChargeViewState extends State<ThepeerDirectChargeView> {
   /// Javascript channel  onMessageRecieved for events sent by Thepeer
   void _onMessageReceived(JavaScriptMessage data) {
     try {
-      if (widget.showLogs) ThePeerFunctions.log('Event: -> ${data.message}');
+      if (widget.showLogs) ThepeerFunctions.log('Event: -> ${data.message}');
       _handleResponse(data.message);
     } on Exception {
       if (mounted && widget.onClosed != null) widget.onClosed!();
     } catch (e) {
-      if (widget.showLogs) ThePeerFunctions.log(e.toString());
+      if (widget.showLogs) ThepeerFunctions.log(e.toString());
     }
   }
 
@@ -265,7 +265,7 @@ class _ThepeerDirectChargeViewState extends State<ThepeerDirectChargeView> {
       return NavigationDecision.navigate;
     } else {
       //Prevent external navigations from opening in the webview and open in an external browser instead.
-      ThePeerFunctions.launchExternalUrl(url: url, showLogs: (widget.showLogs));
+      ThepeerFunctions.launchExternalUrl(url: url, showLogs: (widget.showLogs));
       return NavigationDecision.prevent;
     }
   }

--- a/lib/src/views/the_peer_direct_charge_view.dart
+++ b/lib/src/views/the_peer_direct_charge_view.dart
@@ -268,7 +268,8 @@ class _ThepeerDirectChargeViewState extends State<ThepeerDirectChargeView> {
       // Navigate to all urls contianing Thepeer
       return NavigationDecision.navigate;
     } else {
-      // Block all navigations outside Thepeer
+      //Prevent external navigations from opening in the webview and open in an external browser instead.
+      ThePeerFunctions.launchExternalUrl(url: url, showLogs: (widget.showLogs));
       return NavigationDecision.prevent;
     }
   }

--- a/lib/src/views/the_peer_direct_charge_view.dart
+++ b/lib/src/views/the_peer_direct_charge_view.dart
@@ -227,7 +227,7 @@ class _ThepeerDirectChargeViewState extends State<ThepeerDirectChargeView> {
     controller
       ..enableZoom(false)
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      ..addJavaScriptChannel('ThepeerSendClientInterface',
+      ..addJavaScriptChannel('ThepeerDirectChargeClientInterface',
           onMessageReceived: _onMessageReceived)
       ..setNavigationDelegate(NavigationDelegate(
           onPageStarted: (_) async {

--- a/lib/src/views/the_peer_error_view.dart
+++ b/lib/src/views/the_peer_error_view.dart
@@ -6,12 +6,12 @@ import 'package:thepeer_flutter/src/utils/colors.dart';
 import 'package:thepeer_flutter/src/widgets/the_peer_button.dart';
 import 'package:thepeer_flutter/src/widgets/touchable_opacity.dart';
 
-/// ThePeerErrorView States Widget
-class ThePeerErrorView extends StatelessWidget {
+/// ThepeerErrorView States Widget
+class ThepeerErrorView extends StatelessWidget {
   final VoidCallback reload;
   final VoidCallback? onClosed;
 
-  const ThePeerErrorView({
+  const ThepeerErrorView({
     Key? key,
     this.onClosed,
     required this.reload,

--- a/lib/src/views/the_peer_send_view.dart
+++ b/lib/src/views/the_peer_send_view.dart
@@ -69,7 +69,7 @@ class ThepeerSendView extends StatefulWidget {
             topRight: Radius.circular(10),
           ),
           child: SizedBox(
-            height: MediaQuery.of(context).size.height * 0.9,
+            height: MediaQuery.of(context).size.height,
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [

--- a/lib/src/views/the_peer_send_view.dart
+++ b/lib/src/views/the_peer_send_view.dart
@@ -248,7 +248,7 @@ class _ThepeerSendViewState extends State<ThepeerSendView> {
   NavigationDecision _handleNavigationInterceptor(NavigationRequest request) {
     final url = request.url.toLowerCase();
 
-    if (url.contains('groot.thepeer.co') || url.contains('chain.thepeer.co')) {
+    if (url.contains(ThepeerFunctions.domainName)) {
       // Navigate to all urls contianing Thepeer
       return NavigationDecision.navigate;
     } else {

--- a/lib/src/views/the_peer_send_view.dart
+++ b/lib/src/views/the_peer_send_view.dart
@@ -19,7 +19,7 @@ import 'package:thepeer_flutter/src/views/the_peer_error_view.dart';
 
 class ThepeerSendView extends StatefulWidget {
   /// Public Key from your https://app.withThepeer.com/apps
-  final ThePeerData data;
+  final ThepeerData data;
 
   /// Success callback
   final ValueChanged<dynamic>? onSuccess;
@@ -120,7 +120,7 @@ class _ThepeerSendViewState extends State<ThepeerSendView> {
     _handleInit();
   }
 
-  String get createUrl => ThePeerFunctions.createUrl(
+  String get createUrl => ThepeerFunctions.createUrl(
         data: widget.data,
         sdkType: 'send',
       ).toString();
@@ -136,7 +136,7 @@ class _ThepeerSendViewState extends State<ThepeerSendView> {
           if (hasError == true) {
             return Center(
               child: widget.errorWidget ??
-                  ThePeerErrorView(
+                  ThepeerErrorView(
                     onClosed: widget.onClosed,
                     reload: () async {
                       await _controller.reload();
@@ -171,7 +171,7 @@ class _ThepeerSendViewState extends State<ThepeerSendView> {
   /// Inject JS code to be run in webview
   Future<void> _injectPeerStack(WebViewController controller) async {
     await controller.runJavaScript(
-      ThePeerFunctions.peerMessageHandler(
+      ThepeerFunctions.peerMessageHandler(
         'ThepeerSendClientInterface',
       ),
     );
@@ -195,7 +195,7 @@ class _ThepeerSendViewState extends State<ThepeerSendView> {
           return;
       }
     } catch (e) {
-      if (widget.showLogs == true) ThePeerFunctions.log(e.toString());
+      if (widget.showLogs == true) ThepeerFunctions.log(e.toString());
     }
   }
 
@@ -218,7 +218,7 @@ class _ThepeerSendViewState extends State<ThepeerSendView> {
           },
           onWebResourceError: (e) {
             hasError = true;
-            if (widget.showLogs) ThePeerFunctions.log(e.toString());
+            if (widget.showLogs) ThepeerFunctions.log(e.toString());
           },
           onPageFinished: (_) async {
             isLoading = false;
@@ -236,12 +236,12 @@ class _ThepeerSendViewState extends State<ThepeerSendView> {
 
   void _onMessageReceived(JavaScriptMessage data) {
     try {
-      if (widget.showLogs) ThePeerFunctions.log('Event: -> ${data.message}');
+      if (widget.showLogs) ThepeerFunctions.log('Event: -> ${data.message}');
       _handleResponse(data.message);
     } on Exception {
       if (mounted && widget.onClosed != null) widget.onClosed!();
     } catch (e) {
-      if (widget.showLogs) ThePeerFunctions.log(e.toString());
+      if (widget.showLogs) ThepeerFunctions.log(e.toString());
     }
   }
 
@@ -253,7 +253,7 @@ class _ThepeerSendViewState extends State<ThepeerSendView> {
       return NavigationDecision.navigate;
     } else {
       //Prevent external navigations from opening in the webview and open in an external browser instead.
-      ThePeerFunctions.launchExternalUrl(url: url, showLogs: (widget.showLogs));
+      ThepeerFunctions.launchExternalUrl(url: url, showLogs: (widget.showLogs));
       return NavigationDecision.prevent;
     }
   }

--- a/lib/src/views/the_peer_send_view.dart
+++ b/lib/src/views/the_peer_send_view.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/cupertino.dart';
@@ -12,6 +11,7 @@ import 'package:thepeer_flutter/src/model/thepeer_success_model.dart';
 import 'package:thepeer_flutter/src/utils/functions.dart';
 import 'package:thepeer_flutter/src/widgets/the_peer_loader.dart';
 import 'package:webview_flutter/webview_flutter.dart';
+import 'package:webview_flutter_android/webview_flutter_android.dart';
 
 import 'package:thepeer_flutter/src/model/thepeer_data.dart';
 import 'package:thepeer_flutter/src/utils/extensions.dart';
@@ -97,8 +97,7 @@ class ThepeerSendView extends StatefulWidget {
 }
 
 class _ThepeerSendViewState extends State<ThepeerSendView> {
-  final _controller = Completer<WebViewController>();
-  Future<WebViewController> get _webViewController => _controller.future;
+  late final WebViewController _controller;
 
   bool _isLoading = true;
   bool get isLoading => _isLoading;
@@ -141,7 +140,7 @@ class _ThepeerSendViewState extends State<ThepeerSendView> {
                   ThePeerErrorView(
                     onClosed: widget.onClosed,
                     reload: () async {
-                      await (await _webViewController).reload();
+                      await _controller.reload();
                     },
                   ),
             );
@@ -157,25 +156,8 @@ class _ThepeerSendViewState extends State<ThepeerSendView> {
                 ],
 
                 /// Thepeer Webview
-                WebView(
-                  initialUrl: '$createUrl',
-                  onWebViewCreated: _controller.complete,
-                  javascriptChannels: _thepeerJavascriptChannel,
-                  javascriptMode: JavascriptMode.unrestricted,
-                  zoomEnabled: false,
-                  debuggingEnabled: true,
-                  onPageStarted: (_) async {
-                    isLoading = true;
-                  },
-                  onWebResourceError: (e) {
-                    hasError = true;
-                    if (widget.showLogs) ThePeerFunctions.log(e.toString());
-                  },
-                  onPageFinished: (_) async {
-                    isLoading = false;
-                    await _injectPeerStack(await _controller.future);
-                  },
-                  navigationDelegate: _handleNavigationInterceptor,
+                WebViewWidget(
+                  controller: _controller,
                 ),
               ],
             );
@@ -189,30 +171,12 @@ class _ThepeerSendViewState extends State<ThepeerSendView> {
 
   /// Inject JS code to be run in webview
   Future<void> _injectPeerStack(WebViewController controller) async {
-    await controller.runJavascript(
+    await controller.runJavaScript(
       ThePeerFunctions.peerMessageHandler(
         'ThepeerSendClientInterface',
       ),
     );
   }
-
-  /// Javascript channel for events sent by Thepeer
-  Set<JavascriptChannel> get _thepeerJavascriptChannel => {
-        JavascriptChannel(
-          name: 'ThepeerSendClientInterface',
-          onMessageReceived: (JavascriptMessage data) {
-            try {
-              if (widget.showLogs)
-                ThePeerFunctions.log('Event: -> ${data.message}');
-              _handleResponse(data.message);
-            } on Exception {
-              if (mounted && widget.onClosed != null) widget.onClosed!();
-            } catch (e) {
-              if (widget.showLogs) ThePeerFunctions.log(e.toString());
-            }
-          },
-        )
-      };
 
   /// Parse event from javascript channel
   void _handleResponse(String res) async {
@@ -241,7 +205,47 @@ class _ThepeerSendViewState extends State<ThepeerSendView> {
   /// Handle WebView initialization
   void _handleInit() async {
     await SystemChannels.textInput.invokeMethod<String>('TextInput.hide');
-    if (Platform.isAndroid) WebView.platform = SurfaceAndroidWebView();
+
+    final WebViewController controller =
+        WebViewController.fromPlatformCreationParams(
+            PlatformWebViewControllerCreationParams());
+
+    controller
+      ..enableZoom(false)
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..addJavaScriptChannel('ThepeerSendClientInterface',
+          onMessageReceived: _onMessageReceived)
+      ..setNavigationDelegate(NavigationDelegate(
+          onPageStarted: (_) async {
+            isLoading = true;
+          },
+          onWebResourceError: (e) {
+            hasError = true;
+            if (widget.showLogs) ThePeerFunctions.log(e.toString());
+          },
+          onPageFinished: (_) async {
+            isLoading = false;
+            await _injectPeerStack(_controller);
+          },
+          onNavigationRequest: _handleNavigationInterceptor))
+      ..loadRequest(Uri.parse('$createUrl'));
+    if (controller.platform is AndroidWebViewController) {
+      AndroidWebViewController.enableDebugging(true);
+    }
+    _controller = controller;
+  }
+
+  /// Javascript channel  onMessageRecieved for events sent by Thepeer
+
+  void _onMessageReceived(JavaScriptMessage data) {
+    try {
+      if (widget.showLogs) ThePeerFunctions.log('Event: -> ${data.message}');
+      _handleResponse(data.message);
+    } on Exception {
+      if (mounted && widget.onClosed != null) widget.onClosed!();
+    } catch (e) {
+      if (widget.showLogs) ThePeerFunctions.log(e.toString());
+    }
   }
 
   NavigationDecision _handleNavigationInterceptor(NavigationRequest request) {

--- a/lib/src/views/the_peer_send_view.dart
+++ b/lib/src/views/the_peer_send_view.dart
@@ -255,7 +255,8 @@ class _ThepeerSendViewState extends State<ThepeerSendView> {
       // Navigate to all urls contianing Thepeer
       return NavigationDecision.navigate;
     } else {
-      // Block all navigations outside Thepeer
+      //Prevent external navigations from opening in the webview and open in an external browser instead.
+      ThePeerFunctions.launchExternalUrl(url: url, showLogs: (widget.showLogs));
       return NavigationDecision.prevent;
     }
   }


### PR DESCRIPTION
### Issue/Ticket
- Implement a navigation handler for external links? So links we dump on the SDK would trigger the device's browser and not open in the same WebView.
- Migration of `webview_flutter` from version 3.0 to 4.0 has some breaking changes that weren’t implemented.
- Convert the dialog to fullscreen for better UX flow 

### What has changed:
A. [Redirect external navigation to browser](https://github.com/thepeerstack/flutter-sdk/commit/62eb3e2aef5f398ddb5b34715f6b2f34192e2dce)
- Updated the _handleNavigationInterceptor to open external URLs in a browser. 
- Added function `launchExternalUrl` to launch the URL to the `ThePeerFunctions` class.

B. [fix webview_flutter 3.0 to 4.0 migration changes](https://github.com/thepeerstack/flutter-sdk/commit/576545961d8048cca0c4e6c900305d54451a6f49)
- Migrated `Webview` to `WebViewWidget` among other breaking changes. [See more here](https://pub.dev/packages/webview_flutter)

C. [updated dialog to fullscreen](https://github.com/thepeerstack/flutter-sdk/pull/5/commits/c5cd103bc28cb4210376fffd8d39f57b5a4b773b)
- Changed the dialog height to 100% height from 90% height for the checkout, send, and direct charge views.

D. [changed ThePeer instance to Thepeer](https://github.com/thepeerstack/flutter-sdk/pull/5/commits/24ff2f69dd658a4b0881c9633c150e01d21697d2)
Changed all instances of text `ThePeer` to `Thepeer`.**This is a breaking change**
 - `ThePeerCheckoutView` changed to `ThepeerCheckoutView`
  - `ThePeerDirectChargeView` changed to `ThepeerDirectChargeView`
  - `ThePeerCheckoutView` changed to `ThepeerCheckoutView`
  - `ThePeerData` changed to `ThepeerData`

E. [removed reference to dev domain](https://github.com/thepeerstack/flutter-sdk/pull/5/commits/520e51d9f8f53becbc13ae762889cbe96b6229c4)
 - Replaced reference to test and prod domain name with a dynamic domain name gotten from the base url.
 - Added base url to const file.
